### PR TITLE
feat: 디테일 페이지 구현(#9)

### DIFF
--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,14 +1,18 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-function useFetch({ options = {}, query }) {
+function useFetch({ options = {}, queryFn, queryKey = [] }) {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  const queryFnRef = useRef(queryFn);
+  queryFnRef.current = queryFn;
+
   const serializedOptions = JSON.stringify(options);
+  const serializedQueryKey = JSON.stringify(queryKey);
 
   useEffect(() => {
-    if (!query) {
+    if (!queryFnRef.current) {
       setIsLoading(false);
       return;
     }
@@ -23,7 +27,7 @@ function useFetch({ options = {}, query }) {
       try {
         const parsedOptions = JSON.parse(serializedOptions);
 
-        const result = await query({
+        const result = await queryFnRef.current({
           ...parsedOptions,
           signal: controller.signal,
         });
@@ -43,7 +47,7 @@ function useFetch({ options = {}, query }) {
     return () => {
       controller.abort();
     };
-  }, [query, serializedOptions]);
+  }, [serializedQueryKey, serializedOptions]);
 
   return { data, error, isLoading };
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,10 +6,9 @@ import { BrowserRouter } from "react-router";
 
 import App from "./App.jsx";
 
+// useFetch의 AbortController 때문에 로딩 상태가 표시되지 않아서 StrictMode를 사용하지 않음
 createRoot(document.getElementById("root")).render(
-  <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </StrictMode>,
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>,
 );

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,4 +1,73 @@
+import { fetchMovieDetails } from "@api/fetchMovieDetails";
+import { TMDB_IMAGE_URL } from "@constants/urls";
+import useFetch from "@hooks/useFetch";
+import { useParams } from "react-router";
+
 const Detail = () => {
-  return <div>Detail</div>;
+  const { movieId } = useParams();
+
+  const { data, error, isLoading } = useFetch({
+    queryFn: (options) => fetchMovieDetails({ movieId, ...options }),
+    queryKey: [movieId],
+  });
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  const { backdropPath, genres, overview, title, voteAverage } = data;
+
+  return (
+    <main className="min-h-screen bg-neutral-50 py-16 text-neutral-900">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-4 lg:flex-row lg:items-start">
+        <div className="flex w-full items-center justify-center lg:max-w-sm">
+          <img
+            alt={title}
+            className="aspect-video w-full rounded-3xl object-cover shadow-2xl lg:aspect-2/3"
+            src={TMDB_IMAGE_URL + backdropPath}
+          />
+        </div>
+
+        <article className="flex w-full flex-1 flex-col gap-8">
+          <header className="space-y-4">
+            <div>
+              <p className="text-sm tracking-widest text-neutral-500 uppercase">
+                Movie Detail
+              </p>
+              <h1 className="mt-1 text-3xl leading-tight font-bold text-neutral-900 lg:text-4xl">
+                {title}
+              </h1>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-4">
+              <span className="flex items-center gap-2 rounded-full border border-yellow-500 px-3 py-1 text-sm text-yellow-600">
+                {voteAverage.toFixed(1)}
+              </span>
+              <ul className="flex flex-wrap gap-2 text-sm text-neutral-700">
+                {genres.map((genre) => (
+                  <li
+                    className="rounded-full bg-neutral-200 px-3 py-1"
+                    key={genre.id ?? genre.name}
+                  >
+                    {genre.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </header>
+
+          <section className="rounded-3xl bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-neutral-900">줄거리</h2>
+            <p className="mt-3 leading-relaxed text-neutral-700">{overview}</p>
+          </section>
+        </article>
+      </div>
+    </main>
+  );
 };
+
 export default Detail;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import useFetch from "@hooks/useFetch";
 
 const Home = () => {
   const { data, error, isLoading } = useFetch({
-    query: fetchPopularMovieList,
+    queryFn: fetchPopularMovieList,
   });
 
   if (isLoading) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #9

## 📝 작업 내용

> 디테일 페이지 구현

- useFetch의 abortController 때문에 로딩상태가 표시되지 않아 strict mode 제거
- useFetch가 queryFn, queryKey를 받도록 수정(사용하지 않을 경우 useCallback을 사용해야 할 수 있음)
- detail 페이지 구현

