### PR TITLE
feat: 헤더 구현(#11)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import MainLayout from "@components/layout/MainLayout";
 import { ROUTE_PATHS } from "@constants/urls";
-import { Detail, Home, NotFound } from "@pages";
+import { Detail, Home, NotFound, Search } from "@pages";
 import { Route, Routes } from "react-router";
 
 function App() {
@@ -12,6 +12,10 @@ function App() {
     {
       element: <Detail />,
       path: ROUTE_PATHS.DETAIL,
+    },
+    {
+      element: <Search />,
+      path: ROUTE_PATHS.SEARCH,
     },
     {
       element: <NotFound />,

--- a/src/api/fetchSearchMovies.js
+++ b/src/api/fetchSearchMovies.js
@@ -1,0 +1,35 @@
+import { API_ROUTES, TMDB_API_URL } from "@constants";
+
+const defaultOptions = {
+  headers: {
+    Authorization: `Bearer ${import.meta.env.VITE_TMDB_API_ACCESS_TOKEN}`,
+  },
+};
+
+export const fetchSearchMovies = async ({ page = 1, query, signal }) => {
+  const apiUrl = new URL(API_ROUTES.SEARCH, TMDB_API_URL);
+  apiUrl.searchParams.set("page", page);
+  apiUrl.searchParams.set("language", "ko-KR");
+  apiUrl.searchParams.set("query", query);
+
+  const response = await fetch(apiUrl, {
+    ...defaultOptions,
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  const result = await response.json();
+
+  return {
+    page: result.page,
+    results: result.results.map((movie) => ({
+      id: movie.id,
+      posterPath: movie.poster_path,
+      title: movie.title,
+      voteAverage: movie.vote_average,
+    })),
+  };
+};

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,2 +1,3 @@
 export * from "./fetchMovieDetails";
 export * from "./fetchPopularMovieList";
+export * from "./fetchSearchMovies";

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,1 +1,4 @@
+export { default as Header } from "./layout/Header";
 export { default as MainLayout } from "./layout/MainLayout";
+export { default as SearchBar } from "./layout/SearchBar";
+export { default as MovieCard } from "./movie/MovieCard";

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,0 +1,23 @@
+import { SearchBar } from "@components/index";
+import { ROUTE_PATHS } from "@constants/urls";
+import { Link } from "react-router";
+
+const Header = () => {
+  return (
+    <header>
+      <div className="mx-auto flex h-16 items-center justify-between bg-neutral-50 px-6 py-2">
+        <div className="flex flex-1 justify-start">
+          <h1>
+            <Link to={ROUTE_PATHS.HOME}>SCARECROW MOVIE</Link>
+          </h1>
+        </div>
+        <div className="flex flex-[1.5] justify-center">
+          <SearchBar />
+        </div>
+        <div className="flex flex-1 justify-end">right side</div>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -1,13 +1,14 @@
-import React from "react";
+import { Header } from "@components";
 import { Outlet } from "react-router";
 
 function MainLayout() {
   return (
-    <>
-      <main>
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">
         <Outlet />
       </main>
-    </>
+    </div>
   );
 }
 

--- a/src/components/layout/SearchBar.jsx
+++ b/src/components/layout/SearchBar.jsx
@@ -1,0 +1,114 @@
+import { ROUTE_PATHS } from "@constants/urls";
+import { useDebounce } from "@hooks";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+const SearchBar = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebounce({ delay: 500, value: searchQuery });
+
+  /**
+   * useEffect가 실행되어야 하는지 여부
+   * - true: 사용자가 방금 타이핑했으니, 디바운싱이 끝나면 useEffect가 URL을 변경해야 함
+   * - false: 사용자가 방금 타이핑하지 않았으니, useEffect가 URL을 변경하지 않아도 됨
+   */
+  const shouldSyncQueryRef = useRef(false);
+
+  /**
+   * 검색 페이지가 아닐 경우 검색어 초기화
+   * - useLayoutEffect는 렌더링 직전에 실행되므로, 렌더링 후에 실행되는 useEffect와 달리 렌더링 후에 실행되지 않음
+   * - 렌더링 직전에 실행: DOM 변경이 완료된 후, 브라우저가 화면을 그리기(paint) 전에 동기적으로 실행
+   *
+   * - 현재 경로가 search 페이지가 아닐 경우 검색어 초기화
+   * - 현재 경로가 search 페이지일 경우 searchParams의 query를 searchQuery로 설정
+   */
+  useLayoutEffect(() => {
+    if (location.pathname !== ROUTE_PATHS.SEARCH) {
+      shouldSyncQueryRef.current = false;
+      setSearchQuery("");
+      return;
+    }
+
+    const currentQueryParam =
+      new URLSearchParams(location.search).get("query") ?? "";
+
+    shouldSyncQueryRef.current = false;
+    setSearchQuery((prev) =>
+      prev === currentQueryParam ? prev : currentQueryParam,
+    );
+  }, [location.pathname, location.search]);
+
+  /**
+   * URL 변경을 처리하는 useEffect
+   */
+  useEffect(() => {
+    if (!shouldSyncQueryRef.current) {
+      return;
+    }
+
+    const trimmedQuery = debouncedSearchQuery.trim();
+
+    /**
+     * 검색어가 비어있을 경우 쿼리 파라미터를 제거한 URL로 변경
+     *
+     * - http://localhost:5173/search?query= 일 경우 http://localhost:5173/search 로 변경
+     */
+    if (!trimmedQuery) {
+      if (location.pathname === ROUTE_PATHS.SEARCH && location.search !== "") {
+        navigate(ROUTE_PATHS.SEARCH, { replace: true });
+      }
+      shouldSyncQueryRef.current = false;
+      return;
+    }
+
+    /**
+     * 검색어가 존재할 경우 처리
+     *
+     * - 검색어를 인코딩해서 이동할 url을 생성(http://localhost:5173/search?query=검색어)
+     * - 이미 해당 url에 있는 경우 처리하지 않음
+     * - 1) location.pathname이 현재 경로와 같은지 확인
+     * - 2) location.search가 현재 검색어와 같은지 확인
+     */
+    const encodedQuery = encodeURIComponent(trimmedQuery);
+    const targetSearch = `${ROUTE_PATHS.SEARCH}?query=${encodedQuery}`;
+    const isAlreadyOnTarget =
+      location.pathname === ROUTE_PATHS.SEARCH &&
+      location.search === `?query=${encodedQuery}`;
+
+    if (isAlreadyOnTarget) {
+      shouldSyncQueryRef.current = false;
+      return;
+    }
+
+    /**
+     * 이동할 url이 현재 url과 다를 경우 이동
+     */
+    navigate(targetSearch, {
+      replace: location.pathname === ROUTE_PATHS.SEARCH,
+    });
+    shouldSyncQueryRef.current = false;
+  }, [debouncedSearchQuery, location.pathname, location.search, navigate]);
+
+  const handleInputChange = (e) => {
+    /**
+     * 검색어 입력시 shouldSyncQueryRef를 true로 설정
+     */
+    shouldSyncQueryRef.current = true;
+    setSearchQuery(e.target.value);
+  };
+
+  return (
+    <div className="flex w-full items-center justify-center">
+      <input
+        className="w-full rounded-md border border-gray-300 px-4 py-2 text-gray-600 focus:outline-none"
+        onChange={handleInputChange}
+        placeholder="검색어를 입력해주세요"
+        type="text"
+        value={searchQuery}
+      />
+    </div>
+  );
+};
+export default SearchBar;

--- a/src/constants/urls.js
+++ b/src/constants/urls.js
@@ -4,12 +4,14 @@ export const TMDB_IMAGE_URL = "https://image.tmdb.org/t/p/w500/";
 export const API_ROUTES = {
   MOVIE_DETAILS: ({ movieId }) => `movie/${movieId}`,
   POPULAR_MOVIES: "movie/popular",
+  SEARCH: "search/movie",
 };
 
 export const ROUTE_PATHS = {
   DETAIL: "/detail/:movieId",
   HOME: "/",
   NOT_FOUND: "*",
+  SEARCH: "/search",
 };
 
 export const ROUTE_HANDLERS = {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,1 +1,2 @@
+export { default as useDebounce } from "./useDebounce";
 export { default as useFetch } from "./useFetch";

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+const useDebounce = ({ delay = 500, value }) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -22,7 +22,7 @@ const Detail = () => {
   const { backdropPath, genres, overview, title, voteAverage } = data;
 
   return (
-    <main className="min-h-screen bg-neutral-50 py-16 text-neutral-900">
+    <main className="bg-neutral-50 pb-8 text-neutral-900">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-4 lg:flex-row lg:items-start">
         <div className="flex w-full items-center justify-center lg:max-w-sm">
           <img

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import { fetchPopularMovieList } from "@api/fetchPopularMovieList";
-import MovieCard from "@components/movie/MovieCard";
-import useFetch from "@hooks/useFetch";
+import { MovieCard } from "@components";
+import { useFetch } from "@hooks";
 
 const Home = () => {
   const { data, error, isLoading } = useFetch({
@@ -16,7 +16,7 @@ const Home = () => {
   }
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center bg-neutral-50">
       <section className="mx-auto grid grid-cols-2 gap-4 px-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
         {data?.results?.map((movie) => (
           <MovieCard key={movie.id} movie={movie} />

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -1,0 +1,53 @@
+import { fetchSearchMovies } from "@api/fetchSearchMovies";
+import { MovieCard } from "@components";
+import { useFetch } from "@hooks";
+import { useSearchParams } from "react-router";
+
+const Search = () => {
+  const [searchParams] = useSearchParams();
+  const query = (searchParams.get("query") ?? "").trim();
+  const hasQuery = query.length > 0;
+
+  const { data, error, isLoading } = useFetch({
+    queryFn: hasQuery
+      ? (options) => fetchSearchMovies({ query, ...options })
+      : undefined,
+    queryKey: hasQuery ? ["search", query] : ["search"],
+  });
+
+  if (!hasQuery) {
+    return (
+      <div className="flex flex-1 items-center justify-center bg-neutral-50">
+        <p className="text-gray-500">검색어를 입력해주세요.</p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  if (!data?.results?.length) {
+    return (
+      <div className="flex flex-1 items-center justify-center bg-neutral-50">
+        <p className="text-gray-500">검색 결과가 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center bg-neutral-50">
+      <section className="mx-auto grid grid-cols-2 gap-4 px-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+        {data.results.map((movie) => (
+          <MovieCard key={movie.id} movie={movie} />
+        ))}
+      </section>
+    </div>
+  );
+};
+
+export default Search;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,3 +1,4 @@
 export { default as Detail } from "./Detail";
 export { default as Home } from "./Home";
 export { default as NotFound } from "./NotFound";
+export { default as Search } from "./Search";


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #11

## 📝 작업 내용

> 헤더 구현

- search 경로 및 Search 페이지 추가
- 헤더 추가
- fetchSearchMovies query 추가
- components에 Header, SearchBar, MovieCard 배럴 패턴 설정
- MainLayout에 min-h-screen과 flex 적용(main 영역이 화면을 가득 채우도록 설정)
- useDebounce 훅 추가
- Detail 페이지 pb를 8로 수정
