### PR TITLE
feat: 다크모드/라이트모드 구현(#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,250 @@
-# React + Vite
+# 🎬 OZ Movie
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+TMDB API를 활용한 영화 정보 웹 애플리케이션입니다.
 
-Currently, two official plugins are available:
+오즈코딩스쿨 스터디메이트 예시 코드로 사용하기 위해 구현되었습니다.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## 📋 목차
 
-## React Compiler
+- [기술 스택](#-기술-스택)
+- [시작하기](#-시작하기)
+- [프로젝트 구조](#-프로젝트-구조)
+- [개발 컨벤션](#-개발-컨벤션)
+  - [커밋 컨벤션](#커밋-컨벤션)
+  - [브랜치 컨벤션](#브랜치-컨벤션)
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+## 🛠 기술 스택
 
-## Expanding the ESLint configuration
+### Core
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+- **React** (v19.1.1) - UI 라이브러리
+- **React Router** (v7.9.5) - 라우팅
+- **Vite** (v7.1.7) - 빌드 도구
+
+### Styling
+
+- **Tailwind CSS** (v4.1.16) - 유틸리티 우선 CSS 프레임워크
+- **Lucide React** - 아이콘 라이브러리
+
+### UI Components
+
+- **Swiper** (v12.0.3) - 캐러셀/슬라이더
+- **React Spinners** (v0.17.0) - 로딩 스피너
+
+### Code Quality
+
+- **ESLint** (v9.36.0) - 린팅
+- **Prettier** (v3.6.2) - 코드 포맷팅
+- **eslint-plugin-jsx-a11y** - 접근성 검사
+- **eslint-plugin-perfectionist** - 코드 정렬
+
+## 🚀 시작하기
+
+### 사전 요구사항
+
+- Node.js 18.x 이상
+- npm 또는 yarn
+- TMDB API Access Token
+
+### 설치 및 실행
+
+1. 저장소 클론
+
+```bash
+git clone https://github.com/quartzs2/oz-movie.git
+cd oz-movie
+```
+
+2. 의존성 설치
+
+```bash
+npm install
+```
+
+3. 환경 변수 설정
+
+프로젝트 루트에 `.env` 파일을 생성하고 TMDB API Access Token을 설정합니다.(sample.env 참고해주세요)
+
+```env
+VITE_TMDB_API_ACCESS_TOKEN=your_tmdb_api_access_token_here
+```
+
+4. 개발 서버 실행
+
+```bash
+npm run dev
+```
+
+5. 브라우저에서 `http://localhost:5173` 접속
+
+## 📁 프로젝트 구조
+
+```
+oz-movie/
+├── public/                 # 정적 파일
+├── src/
+│   ├── api/               # API 관련 함수
+│   ├── components/        # 재사용 가능한 컴포넌트
+│   │   ├── layout/       # 레이아웃 컴포넌트 (Header, MainLayout, SearchBar)
+│   │   ├── movie/        # 영화 관련 컴포넌트 (MovieCard, Carousel 등)
+│   │   └── ui/           # UI 컴포넌트 (LoadingSpinner, Skeleton, ErrorMessage 등)
+│   ├── contexts/         # Context API (ThemeContext)
+│   ├── hooks/            # 커스텀 훅 (useFetch, useTheme)
+│   ├── pages/            # 페이지 컴포넌트 (Home, Detail, Search, NotFound)
+│   ├── App.jsx           # 메인 앱 컴포넌트
+│   ├── main.jsx          # 진입점
+│   └── index.css         # 전역 스타일
+├── .env                  # 환경 변수
+├── eslint.config.js      # ESLint 설정
+├── vite.config.js        # Vite 설정
+├── tailwind.config.js    # Tailwind 설정
+└── package.json
+```
+
+## 📝 개발 컨벤션
+
+### 커밋 컨벤션
+
+프로젝트는 [Conventional Commits](https://www.conventionalcommits.org/) 기반의 커밋 컨벤션을 따릅니다.
+
+#### 커밋 메시지 구조
+
+```
+<type>: <subject>(#<issue-number>)
+
+[optional body]
+```
+
+#### Type 종류
+
+| Type       | 설명                           | 예시                                   |
+| ---------- | ------------------------------ | -------------------------------------- |
+| `feat`     | 새로운 기능 추가               | `feat: 헤더 구현(#11)`                 |
+| `fix`      | 버그 수정                      | `fix: 검색 결과 중복 표시 수정(#20)`   |
+| `refactor` | 코드 리팩토링 (기능 변경 없음) | `refactor: API 호출 로직 개선(#25)`    |
+| `style`    | 코드 포맷팅, 세미콜론 누락 등  | `style: 코드 포맷팅 적용`              |
+| `chore`    | 빌드, 패키지 매니저 설정 등    | `chore: 초기 개발 환경 설정(#3)`       |
+| `docs`     | 문서 수정                      | `docs: README 업데이트`                |
+| `test`     | 테스트 코드 추가/수정          | `test: MovieCard 컴포넌트 테스트 추가` |
+| `build`    | 빌드 관련 파일 수정            | `build: initial commit`                |
+| `perf`     | 성능 개선                      | `perf: 이미지 로딩 최적화`             |
+| `ci`       | CI 설정 파일 수정              | `ci: GitHub Actions 워크플로우 추가`   |
+
+#### 작성 규칙
+
+1. **제목(subject)**
+   - 50자 이내로 작성
+   - 명령문으로 작성 (예: "추가한다" ❌ → "추가" ⭕)
+   - 마침표를 붙이지 않음
+   - 이슈 번호를 포함 `(#이슈번호)`
+
+2. **본문(body)** (선택사항)
+   - 한 줄 띄우고 작성
+   - 무엇을, 왜 변경했는지 작성
+   - 어떻게 변경했는지는 코드로 충분히 설명 가능한 경우 생략
+
+#### 예시
+
+```bash
+# 좋은 예시
+feat: 다크 모드 구현(#17)
+
+# 이슈 번호가 없는 경우
+docs: README에 환경 변수 설정 가이드 추가
+
+# 본문이 있는 경우
+refactor: useFetch 훅 에러 처리 로직 개선(#30)
+
+- abort시 로딩 상태를 변경하지 않도록 수정하고 strict mode 추가
+```
+
+### 브랜치 컨벤션
+
+#### 브랜치 전략
+
+프로젝트는 Git Flow를 간소화한 브랜치 전략을 사용합니다.
+
+```
+main (배포)
+  ├── develop (개발)
+  │   ├── feature/이슈번호--기능명
+  │   ├── fix/이슈번호--버그명
+  │   ├── refactor/이슈번호--리팩토링명
+  │   ├── style/이슈번호--스타일 수정 작업명
+  │   ├── chore/이슈번호--수정 작업명
+  │   ├── docs/이슈번호--문서 작업명
+  │   ├── test/이슈번호--테스트명
+  │   ├── build/이슈번호--빌드작업명
+  │   ├── perf/이슈번호--성능개선작업명
+  │   └── ci/이슈번호--CI작업명
+```
+
+#### 브랜치 명명 규칙
+
+| 브랜치 종류 | 명명 규칙                           | 설명                           | 예시                              |
+| ----------- | ----------------------------------- | ------------------------------ | --------------------------------- |
+| `main`      | `main`                              | 배포 가능한 상태의 브랜치      | -                                 |
+| `develop`   | `develop`                           | 다음 배포를 위한 개발 브랜치   | -                                 |
+| `feature`   | `feature/<이슈번호>--<기능명>`      | 새로운 기능 개발               | `feature/17--implement-dark-mode` |
+| `fix`       | `fix/<이슈번호>--<버그명>`          | 버그 수정                      | `fix/20--fix-search-duplicate`    |
+| `refactor`  | `refactor/<이슈번호>--<리팩토링명>` | 코드 리팩토링                  | `refactor/25--improve-api-logic`  |
+| `hotfix`    | `hotfix/<이슈번호>--<버그명>`       | 긴급 버그 수정 (main에서 분기) | `hotfix/30--critical-bug-fix`     |
+
+#### 브랜치 작성 규칙
+
+1. 브랜치명은 소문자와 하이픈(`-`)을 사용
+2. 이슈 번호와 기능명은 `--`(이중 하이픈)으로 구분
+3. 기능명은 영어로 작성하며, 단어는 하이픈으로 연결
+4. 간결하고 명확하게 작성
+
+#### 브랜치 워크플로우
+
+1. **기능 개발**
+
+```bash
+# develop 브랜치에서 feature 브랜치 생성
+git switch develop
+git pull
+git switch -c feature/17--implement-dark-mode
+git push -u origin feature/17--implement-dark-mode
+
+# 작업 완료 후 커밋
+git add .
+git commit
+
+# 컨벤션에 맞춰서 커밋 내용을 작성합니다. 다음은 커밋 내용의 예시입니다.
+feat: 다크 모드 구현(#17)
+
+- 시스템 설정에 따라 초기 테마를 설정하는 기능 추가
+- 사용자가 테마를 수동으로 변경할 수 있는 토글 버튼 구현
+
+# 원격 저장소에 푸시
+git push
+
+# GitHub에서 develop 브랜치로 Pull Request 생성
+```
+
+2. **버그 수정**
+
+```bash
+# develop 브랜치에서 fix 브랜치 생성
+git switch develop
+git pull
+git switch -c fix/20--fix-search-duplicate
+git push -u origin fix/20--fix-search-duplicate
+
+# 작업 완료 후 커밋
+git add .
+git commit
+
+# 컨벤션에 맞춰서 커밋 내용을 작성합니다. 다음은 커밋 내용의 예시입니다.
+fix: 검색 결과 중복 표시 수정(#20)
+
+- 검색 API 호출 시 중복된 요청이 발생하던 문제 해결
+- 데이터 키 값을 기준으로 중복 제거 로직 추가
+
+# 원격 저장소에 푸시
+git push
+
+# GitHub에서 develop 브랜치로 Pull Request 생성
+```

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,7 +8,8 @@
       "@utils/*": ["src/utils/*"],
       "@constants/*": ["src/constants/*"],
       "@api/*": ["src/api/*"],
-      "@hooks/*": ["src/hooks/*"]
+      "@hooks/*": ["src/hooks/*"],
+      "@contexts/*": ["src/contexts/*"]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.16",
         "clsx": "^2.1.1",
+        "lucide-react": "^0.553.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router": "^7.9.5",
@@ -4264,6 +4265,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.553.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.553.0.tgz",
+      "integrity": "sha512-BRgX5zrWmNy/lkVAe0dXBgd7XQdZ3HTf+Hwe3c9WK6dqgnj9h+hxV+MDncM88xDWlCq27+TKvHGE70ViODNILw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.16",
     "clsx": "^2.1.1",
+    "lucide-react": "^0.553.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router": "^7.9.5",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import MainLayout from "@components/layout/MainLayout";
 import { ROUTE_PATHS } from "@constants/urls";
+import { ThemeProvider } from "@contexts";
 import { Detail, Home, NotFound, Search } from "@pages";
 import { Route, Routes } from "react-router";
 
@@ -24,13 +25,15 @@ function App() {
   ];
 
   return (
-    <Routes>
-      <Route element={<MainLayout />}>
-        {ROUTES.map((route) => (
-          <Route element={route.element} key={route.path} path={route.path} />
-        ))}
-      </Route>
-    </Routes>
+    <ThemeProvider>
+      <Routes>
+        <Route element={<MainLayout />}>
+          {ROUTES.map((route) => (
+            <Route element={route.element} key={route.path} path={route.path} />
+          ))}
+        </Route>
+      </Routes>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,3 +7,4 @@ export { default as NowPlayingCarousel } from "./movie/NowPlayingCarousel";
 export { default as Carousel } from "./ui/Carousel";
 export { default as ErrorMessage } from "./ui/ErrorMessage";
 export { default as LoadingSpinner } from "./ui/LoadingSpinner";
+export { default as ThemeToggle } from "./ui/ThemeToggle";

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,20 +1,27 @@
-import { SearchBar } from "@components/index";
+import { SearchBar, ThemeToggle } from "@components/index";
 import { ROUTE_PATHS } from "@constants/urls";
 import { Link } from "react-router";
 
 const Header = () => {
   return (
     <header>
-      <div className="mx-auto flex h-16 items-center justify-between bg-neutral-50 px-6 py-2">
+      <div className="mx-auto flex h-16 items-center justify-between bg-neutral-50 px-6 py-2 dark:bg-gray-900">
         <div className="flex flex-1 justify-start">
           <h1>
-            <Link to={ROUTE_PATHS.HOME}>SCARECROW MOVIE</Link>
+            <Link
+              className="text-gray-900 dark:text-gray-100"
+              to={ROUTE_PATHS.HOME}
+            >
+              OZ MOVIE
+            </Link>
           </h1>
         </div>
         <div className="flex flex-[1.5] justify-center">
           <SearchBar />
         </div>
-        <div className="flex flex-1 justify-end">right side</div>
+        <div className="flex flex-1 items-center justify-end">
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   );

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -3,7 +3,7 @@ import { Outlet } from "react-router";
 
 function MainLayout() {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col bg-white dark:bg-gray-950">
       <Header />
       <main className="flex-1">
         <Outlet />

--- a/src/components/layout/SearchBar.jsx
+++ b/src/components/layout/SearchBar.jsx
@@ -102,7 +102,7 @@ const SearchBar = () => {
   return (
     <div className="flex w-full items-center justify-center">
       <input
-        className="w-full rounded-md border border-gray-300 px-4 py-2 text-gray-600 focus:outline-none"
+        className="w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-600 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:placeholder:text-gray-400"
         onChange={handleInputChange}
         placeholder="검색어를 입력해주세요"
         type="text"

--- a/src/components/movie/MovieCard.jsx
+++ b/src/components/movie/MovieCard.jsx
@@ -1,5 +1,6 @@
 import { ROUTE_HANDLERS, TMDB_IMAGE_URL } from "@constants/urls";
 import { cn } from "@utils/cn";
+import { Star as StarIcon } from "lucide-react";
 import { Link } from "react-router";
 
 const MovieCard = ({ movie }) => {
@@ -24,8 +25,9 @@ const MovieCard = ({ movie }) => {
           <h2 className="line-clamp-2 text-sm font-semibold text-white">
             {movie.title}
           </h2>
-          <p className="mt-1 text-xs text-yellow-400">
-            ⭐ {movie.voteAverage.toFixed(1)}
+          <p className="mt-1 flex items-center gap-1 text-xs text-yellow-400">
+            <StarIcon className="h-3 w-3 fill-current" />
+            {movie.voteAverage.toFixed(1)}
           </p>
         </div>
       </Link>

--- a/src/components/movie/NowPlayingCarousel.jsx
+++ b/src/components/movie/NowPlayingCarousel.jsx
@@ -1,5 +1,10 @@
 import { fetchNowPlayingMovies } from "@api/fetchNowPlayingMovies";
-import { Carousel, ErrorMessage, MovieCard, MovieCardSkeleton } from "@components/index";
+import {
+  Carousel,
+  ErrorMessage,
+  MovieCard,
+  MovieCardSkeleton,
+} from "@components/index";
 import { useFetch } from "@hooks";
 import { SwiperSlide } from "swiper/react";
 
@@ -14,11 +19,13 @@ const NowPlayingCarousel = () => {
 
   return (
     <section className="w-full px-4">
-      <h1 className="mt-4 text-xl text-gray-700">NOW PLAYING</h1>
+      <h1 className="mt-4 text-xl text-gray-700 dark:text-gray-200">
+        NOW PLAYING
+      </h1>
       {isLoading ? (
-        <p className="text-sm text-gray-500 invisible">Loading...</p>
+        <p className="invisible text-sm text-gray-500">Loading...</p>
       ) : (
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
           {data.dates.minimum} - {data.dates.maximum}
         </p>
       )}

--- a/src/components/ui/Carousel.css
+++ b/src/components/ui/Carousel.css
@@ -114,6 +114,40 @@
     }
   }
 
+  /* Dark mode styles */
+  &.dark {
+    & .swiper-button-prev,
+    & .swiper-button-next {
+      background: rgba(30, 41, 59, 0.8);
+      border: 1.5px solid rgba(148, 163, 184, 0.3);
+
+      &:hover {
+        border: 2px solid rgb(148, 163, 184);
+      }
+
+      &::before {
+        border-top-color: #e2e8f0;
+        border-right-color: #e2e8f0;
+      }
+    }
+
+    & .swiper-button-disabled::before {
+      border-color: #475569;
+    }
+
+    & .swiper-pagination-bullet {
+      background-color: #475569;
+
+      &:hover {
+        background-color: #64748b;
+      }
+    }
+
+    & .swiper-pagination-bullet-active {
+      background-color: #e2e8f0;
+    }
+  }
+
   /* Responsive adjustments */
   @media (max-width: 640px) {
     padding: 0.5rem 1.5rem;

--- a/src/components/ui/Carousel.jsx
+++ b/src/components/ui/Carousel.jsx
@@ -1,8 +1,10 @@
+import { THEME } from "@constants";
+import { useTheme } from "@hooks";
 import { cn } from "@utils/cn";
-import { Autoplay, Navigation, Pagination } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
+import { Autoplay, Navigation, Pagination } from "swiper/modules";
 import { Swiper } from "swiper/react";
 
 import "./Carousel.css";
@@ -22,6 +24,7 @@ const Carousel = ({
   spaceBetween = 16,
   swiperProps,
 }) => {
+  const { theme } = useTheme();
   const modules = [];
   if (navigation) {
     modules.push(Navigation);
@@ -47,7 +50,11 @@ const Carousel = ({
           : false
       }
       breakpoints={breakpoints || defaultBreakpoints}
-      className={cn(CUSTOM_CAROUSEL_CLASS, className)}
+      className={cn(
+        CUSTOM_CAROUSEL_CLASS,
+        theme === THEME.DARK && THEME.DARK,
+        className,
+      )}
       loop={loop}
       modules={modules}
       navigation={navigation}

--- a/src/components/ui/ErrorMessage.jsx
+++ b/src/components/ui/ErrorMessage.jsx
@@ -3,10 +3,14 @@ const ErrorMessage = ({ error, message }) => {
     message || error?.message || "알 수 없는 오류가 발생했습니다.";
 
   return (
-    <div className="flex h-[80vh] flex-1 items-center justify-center bg-neutral-50 p-8">
-      <div className="flex h-full max-h-[200px] w-full max-w-[300px] flex-col items-center justify-center rounded-lg border border-red-200 bg-red-50 px-6 py-4 text-center shadow-sm">
-        <p className="text-sm font-semibold text-red-800">오류 발생</p>
-        <p className="mt-1 text-sm text-red-600">{displayMessage}</p>
+    <div className="flex h-[80vh] flex-1 items-center justify-center bg-neutral-50 p-8 dark:bg-gray-950">
+      <div className="flex h-full max-h-[200px] w-full max-w-[300px] flex-col items-center justify-center rounded-lg border border-red-200 bg-red-50 px-6 py-4 text-center shadow-sm dark:border-red-800 dark:bg-red-950">
+        <p className="text-sm font-semibold text-red-800 dark:text-red-300">
+          오류 발생
+        </p>
+        <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+          {displayMessage}
+        </p>
       </div>
     </div>
   );

--- a/src/components/ui/LoadingSpinner.jsx
+++ b/src/components/ui/LoadingSpinner.jsx
@@ -7,7 +7,7 @@ const LoadingSpinner = ({
 }) => {
   if (fullscreen) {
     return (
-      <div className="flex min-h-screen flex-1 items-center justify-center bg-neutral-50">
+      <div className="flex min-h-screen flex-1 items-center justify-center bg-neutral-50 dark:bg-gray-950">
         <ClipLoader color={color} loading={true} size={size} />
       </div>
     );

--- a/src/components/ui/Skeleton.jsx
+++ b/src/components/ui/Skeleton.jsx
@@ -4,8 +4,8 @@ const Skeleton = ({ className, ...props }) => {
   return (
     <div
       className={cn(
-        "animate-pulse rounded-md bg-gray-300/20",
-        className
+        "animate-pulse rounded-md bg-gray-300/20 dark:bg-gray-700/30",
+        className,
       )}
       {...props}
     />

--- a/src/components/ui/ThemeToggle.jsx
+++ b/src/components/ui/ThemeToggle.jsx
@@ -1,0 +1,24 @@
+import { THEME } from "@constants";
+import { useTheme } from "@hooks";
+import { Moon as MoonIcon, Sun as SunIcon } from "lucide-react";
+
+const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      className="rounded-lg p-2 transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+      onClick={toggleTheme}
+      type="button"
+    >
+      {theme === THEME.LIGHT ? (
+        <MoonIcon className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+      ) : (
+        <SunIcon className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+      )}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,1 +1,2 @@
+export * from "./theme";
 export * from "./urls";

--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -1,0 +1,4 @@
+export const THEME = {
+  DARK: "dark",
+  LIGHT: "light",
+};

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+import { THEME } from "@constants";
+
+export const ThemeContext = createContext({
+  theme: THEME.LIGHT,
+  toggleTheme: () => {},
+});

--- a/src/contexts/ThemeProvider.jsx
+++ b/src/contexts/ThemeProvider.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+
+import { THEME } from "@constants";
+import { ThemeContext } from "./ThemeContext";
+
+const THEME_LOCAL_STORAGE_KEY = "theme";
+const DARK_CLASS_NAME = "dark";
+const MEDIA_QUERY_DARK_CLASS_NAME = "(prefers-color-scheme: dark)";
+
+const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => {
+    const savedTheme = localStorage.getItem(THEME_LOCAL_STORAGE_KEY);
+    if (savedTheme) {
+      return savedTheme;
+    }
+    if (window.matchMedia(MEDIA_QUERY_DARK_CLASS_NAME).matches) {
+      return THEME.DARK;
+    }
+    return THEME.LIGHT;
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    if (theme === THEME.DARK) {
+      root.classList.add(DARK_CLASS_NAME);
+    } else {
+      root.classList.remove(DARK_CLASS_NAME);
+    }
+
+    localStorage.setItem(THEME_LOCAL_STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prevTheme) =>
+      prevTheme === THEME.LIGHT ? THEME.DARK : THEME.LIGHT,
+    );
+  };
+
+  return <ThemeContext value={{ theme, toggleTheme }}>{children}</ThemeContext>;
+};
+
+export default ThemeProvider;

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -1,0 +1,2 @@
+export { ThemeContext } from "./ThemeContext";
+export { default as ThemeProvider } from "./ThemeProvider";

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,3 @@
 export { default as useDebounce } from "./useDebounce";
 export { default as useFetch } from "./useFetch";
+export { default as useTheme } from "./useTheme";

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,14 @@
+import { ThemeContext } from "@contexts";
+import { useContext } from "react";
+
+const useTheme = () => {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error("useTheme은 ThemeProvider 내에서 사용해야 합니다.");
+  }
+
+  return context;
+};
+
+export default useTheme;

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,3 @@
 @import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,7 +1,8 @@
 import { fetchMovieDetails } from "@api/fetchMovieDetails";
 import { ErrorMessage, LoadingSpinner } from "@components";
 import { TMDB_IMAGE_URL } from "@constants/urls";
-import useFetch from "@hooks/useFetch";
+import { useFetch } from "@hooks";
+import { StarIcon } from "lucide-react";
 import { useParams } from "react-router";
 
 const Detail = () => {
@@ -23,7 +24,7 @@ const Detail = () => {
   const { backdropPath, genres, overview, title, voteAverage } = data;
 
   return (
-    <main className="bg-neutral-50 pb-8 text-neutral-900">
+    <main className="bg-neutral-50 pt-8 pb-8 text-neutral-900 dark:bg-gray-950 dark:text-gray-100">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-4 lg:flex-row lg:items-start">
         <div className="flex w-full items-center justify-center lg:max-w-sm">
           <img
@@ -36,22 +37,23 @@ const Detail = () => {
         <article className="flex w-full flex-1 flex-col gap-8">
           <header className="space-y-4">
             <div>
-              <p className="text-sm tracking-widest text-neutral-500 uppercase">
+              <p className="text-sm tracking-widest text-neutral-500 uppercase dark:text-gray-400">
                 Movie Detail
               </p>
-              <h1 className="mt-1 text-3xl leading-tight font-bold text-neutral-900 lg:text-4xl">
+              <h1 className="mt-1 text-3xl leading-tight font-bold text-neutral-900 lg:text-4xl dark:text-gray-100">
                 {title}
               </h1>
             </div>
 
             <div className="flex flex-wrap items-center gap-4">
-              <span className="flex items-center gap-2 rounded-full border border-yellow-500 px-3 py-1 text-sm text-yellow-600">
+              <span className="flex items-center gap-2 rounded-full border border-yellow-500 px-3 py-1 text-sm text-yellow-600 dark:border-yellow-400 dark:text-yellow-400">
+                <StarIcon className="h-3 w-3 fill-current" />
                 {voteAverage.toFixed(1)}
               </span>
-              <ul className="flex flex-wrap gap-2 text-sm text-neutral-700">
+              <ul className="flex flex-wrap gap-2 text-sm text-neutral-700 dark:text-gray-300">
                 {genres.map((genre) => (
                   <li
-                    className="rounded-full bg-neutral-200 px-3 py-1"
+                    className="rounded-full bg-neutral-200 px-3 py-1 dark:bg-gray-700"
                     key={genre.id ?? genre.name}
                   >
                     {genre.name}
@@ -61,9 +63,13 @@ const Detail = () => {
             </div>
           </header>
 
-          <section className="rounded-3xl bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-neutral-900">줄거리</h2>
-            <p className="mt-3 leading-relaxed text-neutral-700">{overview}</p>
+          <section className="rounded-3xl bg-white p-6 shadow-sm dark:bg-gray-800">
+            <h2 className="text-lg font-semibold text-neutral-900 dark:text-gray-100">
+              줄거리
+            </h2>
+            <p className="mt-3 leading-relaxed text-neutral-700 dark:text-gray-300">
+              {overview}
+            </p>
           </section>
         </article>
       </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,10 @@
 import { fetchPopularMovieList } from "@api/fetchPopularMovieList";
-import { ErrorMessage, MovieCard, MovieCardSkeleton, NowPlayingCarousel } from "@components";
+import {
+  ErrorMessage,
+  MovieCard,
+  MovieCardSkeleton,
+  NowPlayingCarousel,
+} from "@components";
 import { useFetch } from "@hooks";
 
 const Home = () => {
@@ -12,10 +17,12 @@ const Home = () => {
   }
 
   return (
-    <div className="flex flex-col gap-4 bg-neutral-50">
+    <div className="flex flex-col gap-4 bg-neutral-50 dark:bg-gray-950">
       <NowPlayingCarousel />
       <section>
-        <h1 className="px-6 text-xl text-gray-700">POPULAR MOVIES</h1>
+        <h1 className="px-6 text-xl text-gray-700 dark:text-gray-200">
+          POPULAR MOVIES
+        </h1>
         <div className="mx-auto mt-1 grid grid-cols-2 gap-4 px-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
           {isLoading
             ? Array.from({ length: 12 }).map((_, index) => (

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,4 +1,15 @@
 const NotFound = () => {
-  return <div>NotFound</div>;
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-neutral-50 dark:bg-gray-950">
+      <div className="text-center">
+        <h1 className="text-6xl font-bold text-gray-900 dark:text-gray-100">
+          404
+        </h1>
+        <p className="mt-4 text-lg text-gray-600 dark:text-gray-400">
+          페이지를 찾을 수 없습니다.
+        </p>
+      </div>
+    </div>
+  );
 };
 export default NotFound;

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -17,8 +17,10 @@ const Search = () => {
 
   if (!hasQuery) {
     return (
-      <div className="flex flex-1 items-center justify-center bg-neutral-50">
-        <p className="text-gray-500">검색어를 입력해주세요.</p>
+      <div className="flex flex-1 items-center justify-center bg-neutral-50 dark:bg-gray-950">
+        <p className="text-gray-500 dark:text-gray-400">
+          검색어를 입력해주세요.
+        </p>
       </div>
     );
   }
@@ -33,15 +35,17 @@ const Search = () => {
 
   if (!data?.results?.length) {
     return (
-      <div className="flex flex-1 items-center justify-center bg-neutral-50">
-        <p className="text-gray-500">검색 결과가 없습니다.</p>
+      <div className="flex flex-1 items-center justify-center bg-neutral-50 dark:bg-gray-950">
+        <p className="text-gray-500 dark:text-gray-400">
+          검색 결과가 없습니다.
+        </p>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col items-center bg-neutral-50">
-      <section className="mx-auto grid grid-cols-2 gap-4 px-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+    <div className="flex flex-col items-center bg-neutral-50 dark:bg-gray-950">
+      <section className="mx-auto grid grid-cols-2 gap-4 px-4 pt-8 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
         {data.results.map((movie) => (
           <MovieCard key={movie.id} movie={movie} />
         ))}

--- a/vite.config.js
+++ b/vite.config.js
@@ -23,6 +23,10 @@ export default defineConfig({
       },
       { find: "@hooks", replacement: path.resolve(__dirname, "src/hooks") },
       { find: "@api", replacement: path.resolve(__dirname, "src/api") },
+      {
+        find: "@contexts",
+        replacement: path.resolve(__dirname, "src/contexts"),
+      },
     ],
   },
 });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #17

## 📝 작업 내용

> 다크모드/라이트모드 구현

- 다크모드/라이트모드 구현
- 헤더에 토글 추가
- Lucide 아이콘 라이브러리 설치 후 아이콘으로 통일
- readme 수정
- Detail페이지에 상단 패딩 적용
- 검색 결과 페이지 섹션에 상단 패딩 적용

