### PR TITLE
feat: 인증 상태 관리 및 사용자 인증 흐름 구현(#23)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,22 @@
-import MainLayout from "@components/layout/MainLayout";
+import { MainLayout, PublicRoute } from "@components";
 import { ROUTE_PATHS } from "@constants/urls";
-import { ThemeProvider } from "@contexts";
+import { AuthProvider, ThemeProvider } from "@contexts";
 import { Detail, Home, Login, NotFound, Search, SignUp } from "@pages";
 import { Route, Routes } from "react-router";
 
 function App() {
-  const ROUTES = [
+  const AUTH_ROUTES = [
+    {
+      element: <Login />,
+      path: ROUTE_PATHS.LOGIN,
+    },
+    {
+      element: <SignUp />,
+      path: ROUTE_PATHS.SIGNUP,
+    },
+  ];
+
+  const PUBLIC_ROUTES = [
     {
       element: <Home />,
       path: ROUTE_PATHS.HOME,
@@ -19,14 +30,6 @@ function App() {
       path: ROUTE_PATHS.SEARCH,
     },
     {
-      element: <Login />,
-      path: ROUTE_PATHS.LOGIN,
-    },
-    {
-      element: <SignUp />,
-      path: ROUTE_PATHS.SIGNUP,
-    },
-    {
       element: <NotFound />,
       path: ROUTE_PATHS.NOT_FOUND,
     },
@@ -34,13 +37,26 @@ function App() {
 
   return (
     <ThemeProvider>
-      <Routes>
-        <Route element={<MainLayout />}>
-          {ROUTES.map((route) => (
-            <Route element={route.element} key={route.path} path={route.path} />
-          ))}
-        </Route>
-      </Routes>
+      <AuthProvider>
+        <Routes>
+          <Route element={<MainLayout />}>
+            {AUTH_ROUTES.map((route) => (
+              <Route
+                element={<PublicRoute>{route.element}</PublicRoute>}
+                key={route.path}
+                path={route.path}
+              />
+            ))}
+            {PUBLIC_ROUTES.map((route) => (
+              <Route
+                element={route.element}
+                key={route.path}
+                path={route.path}
+              />
+            ))}
+          </Route>
+        </Routes>
+      </AuthProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/auth/PublicRoute.jsx
+++ b/src/components/auth/PublicRoute.jsx
@@ -1,0 +1,22 @@
+import { ROUTE_PATHS } from "@constants/urls";
+import { useAuth } from "@hooks";
+import { Navigate } from "react-router";
+import { ClipLoader } from "react-spinners";
+
+export function PublicRoute({ children }) {
+  const { isLoading, user } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <ClipLoader color="#3b82f6" size={50} />
+      </div>
+    );
+  }
+
+  if (user) {
+    return <Navigate replace to={ROUTE_PATHS.HOME} />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/auth/UserToggle.jsx
+++ b/src/components/auth/UserToggle.jsx
@@ -1,0 +1,37 @@
+import { ROUTE_PATHS } from "@constants/urls";
+import { useAuth } from "@hooks/useAuth";
+import { LogIn as LogInIcon, LogOut as LogOutIcon } from "lucide-react";
+import { Link } from "react-router";
+
+const UserToggle = () => {
+  const { signOut, user } = useAuth();
+
+  const handleSignOut = async () => {
+    await signOut();
+  };
+
+  if (user) {
+    return (
+      <button
+        className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-gray-900 transition-colors hover:bg-gray-200 dark:text-gray-100 dark:hover:bg-gray-800"
+        onClick={handleSignOut}
+        type="button"
+      >
+        <LogOutIcon size={18} />
+        로그아웃
+      </button>
+    );
+  }
+
+  return (
+    <Link
+      className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-gray-900 transition-colors hover:bg-gray-200 dark:text-gray-100 dark:hover:bg-gray-800"
+      to={ROUTE_PATHS.LOGIN}
+    >
+      <LogInIcon size={18} />
+      로그인
+    </Link>
+  );
+};
+
+export default UserToggle;

--- a/src/components/auth/index.js
+++ b/src/components/auth/index.js
@@ -1,0 +1,2 @@
+export { default as PublicRoute } from "./PublicRoute";
+export { default as UserToggle } from "./UserToggle";

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,5 @@
+export { PublicRoute } from "./auth/PublicRoute";
+export { default as UserToggle } from "./auth/UserToggle";
 export { default as AuthFormContainer } from "./form/AuthFormContainer";
 export { default as FormField } from "./form/FormField";
 export { default as Header } from "./layout/Header";

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,4 +1,4 @@
-import { SearchBar, ThemeToggle } from "@components";
+import { SearchBar, ThemeToggle, UserToggle } from "@components";
 import { ROUTE_PATHS } from "@constants/urls";
 import { Link } from "react-router";
 
@@ -19,7 +19,8 @@ const Header = () => {
         <div className="flex flex-[1.5] justify-center">
           <SearchBar />
         </div>
-        <div className="flex flex-1 items-center justify-end">
+        <div className="flex flex-1 items-center justify-end gap-3">
+          <UserToggle />
           <ThemeToggle />
         </div>
       </div>

--- a/src/components/ui/ThemeToggle.jsx
+++ b/src/components/ui/ThemeToggle.jsx
@@ -8,7 +8,7 @@ const ThemeToggle = () => {
   return (
     <button
       aria-label="Toggle theme"
-      className="rounded-lg p-2 transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+      className="cursor-pointer rounded-lg p-2 transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
       onClick={toggleTheme}
       type="button"
     >

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+export const AuthContext = createContext({
+  isLoading: true,
+  signOut: async () => {},
+  user: null,
+});

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -1,0 +1,34 @@
+import { supabase } from "@api";
+import { AuthContext } from "@contexts";
+import { useEffect, useState } from "react";
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setUser(session?.user ?? null);
+      setIsLoading(false);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+      setIsLoading(false);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  return (
+    <AuthContext value={{ isLoading, signOut, user }}>
+      {children}
+    </AuthContext>
+  );
+}

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -1,2 +1,4 @@
+export { AuthContext } from "./AuthContext";
+export { AuthProvider } from "./AuthProvider";
 export { ThemeContext } from "./ThemeContext";
 export { default as ThemeProvider } from "./ThemeProvider";

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,4 @@
+export { useAuth } from "./useAuth";
 export { default as useAuthForm } from "./useAuthForm";
 export { default as useDebounce } from "./useDebounce";
 export { default as useFetch } from "./useFetch";

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,12 @@
+import { AuthContext } from "@contexts";
+import { useContext } from "react";
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+
+  if (context === undefined) {
+    throw new Error("useAuth는 AuthProvider 내에서만 사용할 수 있습니다.");
+  }
+
+  return context;
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -3,7 +3,7 @@ import { AuthFormContainer, FormField } from "@components";
 import { ROUTE_PATHS } from "@constants/urls";
 import { useAuthForm } from "@hooks";
 import { loginSchema } from "@utils";
-import { Link, useNavigate } from "react-router";
+import { Link } from "react-router";
 
 const LOGIN_FIELDS = [
   {
@@ -23,8 +23,6 @@ const LOGIN_FIELDS = [
 ];
 
 function Login() {
-  const navigate = useNavigate();
-
   const { errors, formData, handleChange, handleSubmit, isSubmitting } =
     useAuthForm({
       initialData: {
@@ -32,19 +30,13 @@ function Login() {
         password: "",
       },
       onSubmit: async (data) => {
-        const { data: authData, error } =
-          await supabase.auth.signInWithPassword({
-            email: data.email,
-            password: data.password,
-          });
+        const { error } = await supabase.auth.signInWithPassword({
+          email: data.email,
+          password: data.password,
+        });
 
         if (error) {
           throw error;
-        }
-
-        if (authData) {
-          alert("로그인 성공!");
-          navigate(ROUTE_PATHS.HOME);
         }
       },
       schema: loginSchema,

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -3,7 +3,7 @@ import { AuthFormContainer, FormField } from "@components";
 import { ROUTE_PATHS } from "@constants/urls";
 import { useAuthForm } from "@hooks";
 import { signUpSchema } from "@utils";
-import { Link, useNavigate } from "react-router";
+import { Link } from "react-router";
 
 const SIGNUP_FIELDS = [
   {
@@ -37,8 +37,6 @@ const SIGNUP_FIELDS = [
 ];
 
 function SignUp() {
-  const navigate = useNavigate();
-
   const { errors, formData, handleChange, handleSubmit, isSubmitting } =
     useAuthForm({
       initialData: {
@@ -61,9 +59,6 @@ function SignUp() {
         if (error) {
           throw error;
         }
-
-        alert("회원가입이 완료되었습니다!");
-        navigate(ROUTE_PATHS.HOME);
       },
       schema: signUpSchema,
     });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #23

## 📝 작업 내용

> 인증 상태 관리 및 사용자 인증 흐름 구현

- AuthContext 및 AuthProvider 추가하여 전역 인증 상태 관리
- PublicRoute 컴포넌트로 로그인/회원가입 페이지 접근 제어 (로그인 시 자동 홈으로 리다이렉트)
- UserToggle 컴포넌트로 헤더에 로그인/로그아웃 버튼 추가
- useAuth 커스텀 훅으로 인증 상태 및 로그아웃 기능 제공
- 로그인/회원가입 성공 시 불필요한 알림 및 수동 네비게이션 제거 (AuthProvider가 자동 처리)
- React 19+ Context 사용 패턴 적용 (<Context> 직접 사용)

