### PR TITLE
refactor: fetch를 axios로 교체(#33)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.81.0",
         "@tailwindcss/vite": "^4.1.16",
+        "axios": "^1.13.2",
         "clsx": "^2.1.1",
         "es-toolkit": "^1.42.0",
         "lucide-react": "^0.553.0",
@@ -2405,6 +2406,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2429,6 +2436,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2540,7 +2558,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2656,6 +2673,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2851,6 +2880,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2875,7 +2913,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3009,7 +3046,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3019,7 +3055,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3029,7 +3064,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3042,7 +3076,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3550,6 +3583,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3564,6 +3617,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -3584,7 +3653,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3645,7 +3713,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3670,7 +3737,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3745,7 +3811,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3816,7 +3881,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3829,7 +3893,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3845,7 +3908,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4767,7 +4829,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4808,6 +4869,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5257,6 +5339,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.81.0",
     "@tailwindcss/vite": "^4.1.16",
+    "axios": "^1.13.2",
     "clsx": "^2.1.1",
     "es-toolkit": "^1.42.0",
     "lucide-react": "^0.553.0",

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,0 +1,29 @@
+import { TMDB_API_URL } from "@constants";
+import axios from "axios";
+
+const tmdbClient = axios.create({
+  baseURL: TMDB_API_URL,
+  headers: {
+    Authorization: `Bearer ${import.meta.env.VITE_TMDB_API_ACCESS_TOKEN}`,
+    "Content-Type": "application/json",
+  },
+  params: {
+    language: "ko-KR",
+  },
+});
+
+/**
+ * 에러가 요청 취소(Canceled/Aborted)에 의한 것인지 확인하는 유틸리티 함수
+ * @param {Error} error
+ * @returns {boolean}
+ */
+export const isRequestCanceled = (error) => {
+  return (
+    axios.isCancel(error) ||
+    error.name === "AbortError" ||
+    error.name === "CanceledError" ||
+    error.code === "ERR_CANCELED"
+  );
+};
+
+export default tmdbClient;

--- a/src/api/fetchMovieDetails.js
+++ b/src/api/fetchMovieDetails.js
@@ -1,25 +1,12 @@
-import { API_ROUTES, TMDB_API_URL } from "@constants";
-
-const defaultOptions = {
-  headers: {
-    Authorization: `Bearer ${import.meta.env.VITE_TMDB_API_ACCESS_TOKEN}`,
-  },
-};
+import tmdbClient from "@api/axios";
+import { API_ROUTES } from "@constants";
 
 export const fetchMovieDetails = async ({ movieId, signal }) => {
-  const apiUrl = new URL(API_ROUTES.MOVIE_DETAILS({ movieId }), TMDB_API_URL);
-  apiUrl.searchParams.set("language", "ko-KR");
-
-  const response = await fetch(apiUrl, {
-    ...defaultOptions,
+  const response = await tmdbClient.get(API_ROUTES.MOVIE_DETAILS({ movieId }), {
     signal,
   });
 
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-
-  const result = await response.json();
+  const result = response.data;
 
   return {
     backdropPath: result.backdrop_path,

--- a/src/api/fetchNowPlayingMovies.js
+++ b/src/api/fetchNowPlayingMovies.js
@@ -1,26 +1,13 @@
-import { API_ROUTES, TMDB_API_URL } from "@constants";
-
-const defaultOptions = {
-  headers: {
-    Authorization: `Bearer ${import.meta.env.VITE_TMDB_API_ACCESS_TOKEN}`,
-  },
-};
+import tmdbClient from "@api/axios";
+import { API_ROUTES } from "@constants";
 
 export const fetchNowPlayingMovies = async ({ page = 1, signal }) => {
-  const apiUrl = new URL(API_ROUTES.NOW_PLAYING, TMDB_API_URL);
-  apiUrl.searchParams.set("page", page);
-  apiUrl.searchParams.set("language", "ko-KR");
-
-  const response = await fetch(apiUrl, {
-    ...defaultOptions,
+  const response = await tmdbClient.get(API_ROUTES.NOW_PLAYING, {
+    params: { page },
     signal,
   });
 
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-
-  const result = await response.json();
+  const result = response.data;
 
   return {
     dates: result.dates,

--- a/src/api/fetchPopularMovieList.js
+++ b/src/api/fetchPopularMovieList.js
@@ -1,26 +1,13 @@
-import { API_ROUTES, TMDB_API_URL } from "@constants";
-
-const defaultOptions = {
-  headers: {
-    Authorization: `Bearer ${import.meta.env.VITE_TMDB_API_ACCESS_TOKEN}`,
-  },
-};
+import tmdbClient from "@api/axios";
+import { API_ROUTES } from "@constants";
 
 export const fetchPopularMovieList = async ({ page = 1, signal }) => {
-  const apiUrl = new URL(API_ROUTES.POPULAR_MOVIES, TMDB_API_URL);
-  apiUrl.searchParams.set("page", page);
-  apiUrl.searchParams.set("language", "ko-KR");
-
-  const response = await fetch(apiUrl, {
-    ...defaultOptions,
+  const response = await tmdbClient.get(API_ROUTES.POPULAR_MOVIES, {
+    params: { page },
     signal,
   });
 
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-
-  const result = await response.json();
+  const result = response.data;
 
   return {
     page: result.page,

--- a/src/api/fetchSearchMovies.js
+++ b/src/api/fetchSearchMovies.js
@@ -1,27 +1,13 @@
-import { API_ROUTES, TMDB_API_URL } from "@constants";
-
-const defaultOptions = {
-  headers: {
-    Authorization: `Bearer ${import.meta.env.VITE_TMDB_API_ACCESS_TOKEN}`,
-  },
-};
+import tmdbClient from "@api/axios";
+import { API_ROUTES } from "@constants";
 
 export const fetchSearchMovies = async ({ page = 1, query, signal }) => {
-  const apiUrl = new URL(API_ROUTES.SEARCH, TMDB_API_URL);
-  apiUrl.searchParams.set("page", page);
-  apiUrl.searchParams.set("language", "ko-KR");
-  apiUrl.searchParams.set("query", query);
-
-  const response = await fetch(apiUrl, {
-    ...defaultOptions,
+  const response = await tmdbClient.get(API_ROUTES.SEARCH, {
+    params: { page, query },
     signal,
   });
 
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-
-  const result = await response.json();
+  const result = response.data;
 
   return {
     page: result.page,

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,8 +1,24 @@
+import { isRequestCanceled } from "@api/axios";
 import { isEqual } from "es-toolkit";
 import { useEffect, useRef, useState } from "react";
 
-const ABORT_ERROR_NAME = "AbortError";
-
+/**
+ * 비동기 데이터를 가져오기 위한 커스텀 훅입니다.
+ * React Query의 인터페이스와 유사하게 설계되었습니다.
+ *
+ * @template TData - 반환될 데이터의 타입
+ * @template TParams - 쿼리 함수에 전달될 파라미터 객체의 타입
+ *
+ * @param {Object} params
+ * @param {Function} params.queryFn - 데이터를 가져오는 비동기 함수. ({ signal, ...options }) => Promise<TData> 형태여야 합니다.
+ * @param {Array} [params.queryKey=[]] - 쿼리를 다시 실행할 의존성 배열 (이 배열의 값이 변경되면 재요청)
+ * @param {TParams} [params.options={}] - queryFn에 전달할 추가 옵션 객체
+ *
+ * @returns {Object} 결과 객체
+ * @returns {TData|null} result.data - 성공적으로 가져온 데이터 (초기값: null)
+ * @returns {Error|null} result.error - 발생한 에러 객체 (초기값: null)
+ * @returns {boolean} result.isLoading - 로딩 상태 여부 (초기값: true)
+ */
 function useFetch({ options = {}, queryFn, queryKey = [] }) {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
@@ -13,20 +29,17 @@ function useFetch({ options = {}, queryFn, queryKey = [] }) {
     queryFnRef.current = queryFn;
   }, [queryFn]);
 
-  const [memoizedOptions, setMemoizedOptions] = useState(options);
-  const [memoizedQueryKey, setMemoizedQueryKey] = useState(queryKey);
+  const memoizedOptionsRef = useRef(options);
+  if (!isEqual(memoizedOptionsRef.current, options)) {
+    memoizedOptionsRef.current = options;
+  }
+  const memoizedOptions = memoizedOptionsRef.current;
 
-  useEffect(() => {
-    if (!isEqual(memoizedOptions, options)) {
-      setMemoizedOptions(options);
-    }
-  }, [options, memoizedOptions]);
-
-  useEffect(() => {
-    if (!isEqual(memoizedQueryKey, queryKey)) {
-      setMemoizedQueryKey(queryKey);
-    }
-  }, [queryKey, memoizedQueryKey]);
+  const memoizedQueryKeyRef = useRef(queryKey);
+  if (!isEqual(memoizedQueryKeyRef.current, queryKey)) {
+    memoizedQueryKeyRef.current = queryKey;
+  }
+  const memoizedQueryKey = memoizedQueryKeyRef.current;
 
   useEffect(() => {
     if (!queryFnRef.current) {
@@ -51,7 +64,7 @@ function useFetch({ options = {}, queryFn, queryKey = [] }) {
           setData(result);
         }
       } catch (err) {
-        if (err.name !== ABORT_ERROR_NAME) {
+        if (!isRequestCanceled(err)) {
           setError(err);
         }
       } finally {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #33

## 📝 작업 내용

> fetch를 axios로 교체

- axios 라이브러리 추가 및 tmdbClient 인스턴스 생성
- 모든 API 호출 함수를 fetch에서 axios로 마이그레이션
  - fetchMovieDetails
  - fetchNowPlayingMovies
  - fetchPopularMovieList
  - fetchSearchMovies
- 공통 설정(baseURL, headers, params)을 tmdbClient에서 중앙 관리
- useFetch, useInfinityScroll 훅에서 axios 에러 처리 추가
- 중복 코드 제거 및 코드 간소화
- useFetch option과 queryKey를 ref로 관리(불필요한 리렌더링 삭제)
