### PR TITLE
feat: 인증 라우트 가드 리팩토링 및 마이페이지 추가(#43)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,11 @@
-import { MainLayout, PublicRoute } from "@components";
+import { GuestOnlyRoute, MainLayout, PrivateRoute } from "@components";
 import { ROUTE_PATHS } from "@constants";
 import { AuthProvider, ThemeProvider } from "@contexts";
-import { Detail, Home, Login, NotFound, Search, SignUp } from "@pages";
+import { Detail, Home, Login, MyPage, NotFound, Search, SignUp } from "@pages";
 import { Route, Routes } from "react-router";
 
 function App() {
-  const AUTH_ROUTES = [
+  const GUEST_ONLY_ROUTES = [
     {
       element: <Login />,
       path: ROUTE_PATHS.LOGIN,
@@ -35,14 +35,21 @@ function App() {
     },
   ];
 
+  const PRIVATE_ROUTES = [
+    {
+      element: <MyPage />,
+      path: ROUTE_PATHS.MYPAGE,
+    },
+  ];
+
   return (
     <ThemeProvider>
       <AuthProvider>
         <Routes>
           <Route element={<MainLayout />}>
-            {AUTH_ROUTES.map((route) => (
+            {GUEST_ONLY_ROUTES.map((route) => (
               <Route
-                element={<PublicRoute>{route.element}</PublicRoute>}
+                element={<GuestOnlyRoute>{route.element}</GuestOnlyRoute>}
                 key={route.path}
                 path={route.path}
               />
@@ -50,6 +57,13 @@ function App() {
             {PUBLIC_ROUTES.map((route) => (
               <Route
                 element={route.element}
+                key={route.path}
+                path={route.path}
+              />
+            ))}
+            {PRIVATE_ROUTES.map((route) => (
+              <Route
+                element={<PrivateRoute>{route.element}</PrivateRoute>}
                 key={route.path}
                 path={route.path}
               />

--- a/src/components/auth/GuestOnlyRoute.jsx
+++ b/src/components/auth/GuestOnlyRoute.jsx
@@ -3,7 +3,7 @@ import { useAuth } from "@hooks";
 import { Navigate } from "react-router";
 import { ClipLoader } from "react-spinners";
 
-function PublicRoute({ children }) {
+function GuestOnlyRoute({ children }) {
   const { isLoading, user } = useAuth();
 
   if (isLoading) {
@@ -21,4 +21,4 @@ function PublicRoute({ children }) {
   return <>{children}</>;
 }
 
-export default PublicRoute;
+export default GuestOnlyRoute;

--- a/src/components/auth/PrivateRoute.jsx
+++ b/src/components/auth/PrivateRoute.jsx
@@ -1,0 +1,41 @@
+import { ROUTE_PATHS } from "@constants";
+import { useAuth } from "@hooks";
+import { Link } from "react-router";
+import { ClipLoader } from "react-spinners";
+
+function PrivateRoute({ children }) {
+  const { isLoading, user } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <ClipLoader color="#3b82f6" size={50} />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center px-4">
+        <div className="rounded-lg bg-white p-8 text-center shadow-lg dark:bg-gray-800">
+          <h2 className="mb-4 text-2xl font-bold text-gray-900 dark:text-white">
+            로그인이 필요합니다
+          </h2>
+          <p className="mb-6 text-gray-600 dark:text-gray-400">
+            이 페이지를 이용하시려면 로그인이 필요합니다.
+          </p>
+          <Link
+            className="inline-block cursor-pointer rounded-lg bg-gray-950 px-4 py-2 text-white transition-colors hover:bg-gray-800 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
+            to={ROUTE_PATHS.LOGIN}
+          >
+            로그인 하러 가기
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}
+
+export default PrivateRoute;

--- a/src/components/auth/UserToggle.jsx
+++ b/src/components/auth/UserToggle.jsx
@@ -1,35 +1,89 @@
+import { Avatar } from "@components";
 import { ROUTE_PATHS } from "@constants";
 import { useAuth } from "@hooks";
-import { LogIn as LogInIcon, LogOut as LogOutIcon } from "lucide-react";
-import { Link } from "react-router";
+import {
+  LogIn as LogInIcon,
+  LogOut as LogOutIcon,
+  User as UserIcon,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router";
 
 const UserToggle = () => {
   const { signOut, user } = useAuth();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef(null);
+  const navigate = useNavigate();
 
   const handleSignOut = async () => {
     await signOut();
+    setIsOpen(false);
   };
+
+  const handleNavigateToMyPage = () => {
+    navigate(ROUTE_PATHS.MYPAGE);
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
 
   if (user) {
     return (
-      <button
-        className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-gray-900 transition-colors hover:bg-gray-200 dark:text-gray-100 dark:hover:bg-gray-800"
-        onClick={handleSignOut}
-        type="button"
-      >
-        <LogOutIcon size={18} />
-        로그아웃
-      </button>
+      <div className="relative" ref={dropdownRef}>
+        <button
+          className="flex cursor-pointer items-center justify-center rounded-md p-1"
+          onClick={() => setIsOpen(!isOpen)}
+          type="button"
+        >
+          <Avatar size={28} user={user} />
+        </button>
+
+        {isOpen && (
+          <div className="absolute top-full right-0 z-50 mt-2 w-48 rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900">
+            <div className="py-1">
+              <button
+                className="flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-left text-sm text-gray-900 transition-colors hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-800"
+                onClick={handleNavigateToMyPage}
+                type="button"
+              >
+                <UserIcon size={18} />
+                마이페이지
+              </button>
+              <button
+                className="flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-left text-sm text-gray-900 transition-colors hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-800"
+                onClick={handleSignOut}
+                type="button"
+              >
+                <LogOutIcon size={18} />
+                로그아웃
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
     );
   }
 
   return (
     <Link
-      className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-gray-900 transition-colors hover:bg-gray-200 dark:text-gray-100 dark:hover:bg-gray-800"
+      className="flex cursor-pointer items-center rounded-md p-2 hover:bg-gray-200 dark:text-gray-100 dark:hover:bg-gray-700"
       to={ROUTE_PATHS.LOGIN}
     >
-      <LogInIcon size={18} />
-      로그인
+      <LogInIcon size={20} />
     </Link>
   );
 };

--- a/src/components/common/Avatar.jsx
+++ b/src/components/common/Avatar.jsx
@@ -1,0 +1,33 @@
+import { Image } from "@components";
+import { cn } from "@utils";
+import { User as UserIcon } from "lucide-react";
+
+export function Avatar({ size = 18, user }) {
+  const avatarUrl = user?.user_metadata?.avatar_url;
+
+  if (avatarUrl) {
+    return (
+      <Image
+        alt={"프로필"}
+        className="rounded-full object-cover"
+        loading="auto"
+        src={avatarUrl}
+        style={{ height: size, width: size }}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700",
+      )}
+      style={{ height: size, width: size }}
+    >
+      <UserIcon
+        className="text-gray-500 dark:text-gray-400"
+        size={size * 0.6}
+      />
+    </div>
+  );
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,9 +1,11 @@
 export { default as GoogleLoginButton } from "./auth/GoogleLoginButton";
+export { default as GuestOnlyRoute } from "./auth/GuestOnlyRoute";
 export { default as KakaoLoginButton } from "./auth/KakaoLoginButton";
 export { default as LoginForm } from "./auth/LoginForm";
-export { default as PublicRoute } from "./auth/PublicRoute";
+export { default as PrivateRoute } from "./auth/PrivateRoute";
 export { default as SocialLogin } from "./auth/SocialLogin";
 export { default as UserToggle } from "./auth/UserToggle";
+export { Avatar } from "./common/Avatar";
 export { default as AuthFormContainer } from "./form/AuthFormContainer";
 export { default as FormField } from "./form/FormField";
 export { default as Header } from "./layout/Header";

--- a/src/constants/urls.js
+++ b/src/constants/urls.js
@@ -12,6 +12,7 @@ export const ROUTE_PATHS = {
   DETAIL: "/detail/:movieId",
   HOME: "/",
   LOGIN: "/login",
+  MYPAGE: "/mypage",
   NOT_FOUND: "*",
   SEARCH: "/search",
   SIGNUP: "/signup",

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,0 +1,53 @@
+import { Avatar } from "@components";
+import { useAuth } from "@hooks";
+
+function MyPage() {
+  const { user } = useAuth();
+  const userName =
+    user?.user_metadata?.name ||
+    user?.email?.split("@")[0] ||
+    "닉네임을 불러올 수 없습니다.";
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-gray-950">
+      <div className="mx-auto max-w-4xl px-4 py-8">
+        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <h1 className="mb-6 text-2xl font-bold text-gray-900 dark:text-white">
+            마이페이지
+          </h1>
+
+          <div className="flex flex-col items-start gap-8 md:flex-row">
+            <div className="flex w-full flex-col items-center md:w-auto">
+              <div className="mb-2 block w-full text-center text-sm font-medium text-gray-700 dark:text-gray-300">
+                프로필 이미지
+              </div>
+              <Avatar size={120} user={user} />
+            </div>
+
+            <div className="w-full flex-1 space-y-4">
+              <div>
+                <div className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  닉네임
+                </div>
+                <p className="rounded-md border border-gray-300 bg-gray-50 px-4 py-2 text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white">
+                  {userName}
+                </p>
+              </div>
+
+              <div>
+                <div className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  이메일
+                </div>
+                <p className="rounded-md border border-gray-300 bg-gray-50 px-4 py-2 text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white">
+                  {user?.email}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MyPage;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 export { default as Detail } from "./Detail";
 export { default as Home } from "./Home";
 export { default as Login } from "./Login";
+export { default as MyPage } from "./MyPage";
 export { default as NotFound } from "./NotFound";
 export { default as Search } from "./Search";
 export { default as SignUp } from "./SignUp";


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #43

## 📝 작업 내용

> 인증 라우트 가드 리팩토링 및 마이페이지 추가

- AUTH_ROUTES를 GUEST_ONLY_ROUTES로 변경
- PublicRoute를 GuestOnlyRoute로 변경
- PRIVATE_ROUTES 추가
- 마이페이지 추가
- UserToggle이 로그인 시 유저 썸네일을 표시하도록 구현

